### PR TITLE
tools: improve model checker

### DIFF
--- a/tools/checker/Makefile
+++ b/tools/checker/Makefile
@@ -23,7 +23,7 @@ cnfuzz: cnfuzz.c Makefile
 drat-trim: drat-trim.c
 	gcc -O2 -o drat-trim drat-trim.c -static -lrt
 
-verify: 
+verify: verify_model.c
 	g++ verify_model.c -o verify -O3 
 
 clean:

--- a/tools/checker/verify_model.c
+++ b/tools/checker/verify_model.c
@@ -154,6 +154,7 @@ static int libpdex_satisfies_problem(polarity_t *model, size_t model_ctr, litera
 
             // Model too small
             if (var >= model_ctr) {
+                printf("found variable that is not present in model: %d\n", var);
                 return 0;
             }
 


### PR DESCRIPTION
Make sure the verifier is rebuild. Furthermore, bail if models do not fit
the formula restrictions.