### PR TITLE
coprocessor: do not reset white file to 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,18 @@ env:
 #    packages:
 #      - cmake-data
 #      - cmake
-#      - g++-5
+#      - g++-8
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -q
   - sudo apt-get remove gcc g++
-  - sudo apt-get install g++-5 gcc-5 -y
+  - sudo apt-get install g++-8 gcc-8 -y
   - sudo apt-get install picosat
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
-  - sudo update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-5 60
-  - sudo update-alternatives --install /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-5 60
-  - sudo update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/x86_64-linux-gnu-gcc-5 60 --slave /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/x86_64-linux-gnu-g++-5
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+  - sudo update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-8 60
+  - sudo update-alternatives --install /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-8 60
+  - sudo update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/x86_64-linux-gnu-gcc-8 60 --slave /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/x86_64-linux-gnu-g++-8
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,8 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     message(STATUS "enable verbose compiler warnings")
     add_definitions("-Wall -Wextra -ffloat-store -Wno-unused-but-set-variable"
                     "-Wno-unused-variable -Wno-unused-function -Wno-unused-parameter"
-                    "-Wno-sign-compare -Wno-parentheses -Wno-delete-non-virtual-dtor")
+                    "-Wno-sign-compare -Wno-parentheses -Wno-delete-non-virtual-dtor"
+                    "-Wclass-memaccess")
    endif()
    if(QUIET)
      message(STATUS "disable #warnings")

--- a/coprocessor/Coprocessor.cc
+++ b/coprocessor/Coprocessor.cc
@@ -1300,7 +1300,7 @@ void Preprocessor::initializePreprocessor()
         if (config.opt_verbose > 0) { cerr << "c locked " << lockedWhiteVars << " white variables" << endl; }
 
         // do not repeat this process in the future -> delete pointer to file name
-        config.opt_whiteList = 0;
+        config.opt_whiteList = "";
     }
     /*
     uint32_t clausesSize = (*solver).clauses.size();


### PR DESCRIPTION
When setting the white file back to 0, an exception is thrown. To
avoid this behavior, set the file name to an empty string.